### PR TITLE
Enable `configSUPPORT_STATIC_ALLOCATION`

### DIFF
--- a/src/Arduino_FreeRTOS.h
+++ b/src/Arduino_FreeRTOS.h
@@ -100,9 +100,6 @@
 #include "portmacro.h"
 #include "portable.h"
 
-/* Variant (AVR) specific configuration options. */
-#include "FreeRTOSVariant.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -1066,6 +1063,9 @@ typedef struct xSTATIC_TIMER
 #ifdef __cplusplus
 }
 #endif
+
+/* Variant (AVR) specific configuration options. */
+#include "FreeRTOSVariant.h"
 
 #endif /* INC_ARDUINO_FREERTOS_H */
 

--- a/src/FreeRTOSConfig.h
+++ b/src/FreeRTOSConfig.h
@@ -79,7 +79,7 @@
  * application requirements.
  *
  * THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
- * FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE. 
+ * FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.
  *
  * See http://www.freertos.org/a00110.html.
  *----------------------------------------------------------*/
@@ -107,6 +107,7 @@
 #define configUSE_MALLOC_FAILED_HOOK        1
 
 #define configSUPPORT_DYNAMIC_ALLOCATION    1
+#define configSUPPORT_STATIC_ALLOCATION     1
 
 /* Timer definitions. */
 #define configUSE_TIMERS                    1

--- a/src/FreeRTOSConfig.h
+++ b/src/FreeRTOSConfig.h
@@ -107,7 +107,7 @@
 #define configUSE_MALLOC_FAILED_HOOK        1
 
 #define configSUPPORT_DYNAMIC_ALLOCATION    1
-#define configSUPPORT_STATIC_ALLOCATION     1
+#define configSUPPORT_STATIC_ALLOCATION     0
 
 /* Timer definitions. */
 #define configUSE_TIMERS                    1

--- a/src/FreeRTOSVariant.h
+++ b/src/FreeRTOSVariant.h
@@ -42,6 +42,13 @@ void vApplicationIdleHook( void );
 void vApplicationMallocFailedHook( void );
 void vApplicationStackOverflowHook( TaskHandle_t xTask, portCHAR *pcTaskName );
 
+void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer,
+                                    StackType_t **ppxIdleTaskStackBuffer,
+                                    uint32_t *pulIdleTaskStackSize );
+void vApplicationGetTimerTaskMemory( StaticTask_t **ppxTimerTaskTCBBuffer,
+                                     StackType_t **ppxTimerTaskStackBuffer,
+                                     uint32_t *pulTimerTaskStackSize );
+
 /*-----------------------------------------------------------*/
 
 #ifdef __cplusplus

--- a/src/heap_3.c
+++ b/src/heap_3.c
@@ -91,10 +91,7 @@ task.h is included from an application file. */
 
 #undef MPU_WRAPPERS_INCLUDED_FROM_API_FILE
 
-#if( configSUPPORT_DYNAMIC_ALLOCATION == 0 )
-	#error This file must not be used if configSUPPORT_DYNAMIC_ALLOCATION is 0
-#endif
-
+#if( configSUPPORT_DYNAMIC_ALLOCATION > 0 )
 /*-----------------------------------------------------------*/
 
 void *pvPortMalloc( size_t xWantedSize )
@@ -135,5 +132,6 @@ void vPortFree( void *pv )
 	}
 }
 
+#endif /* ( configSUPPORT_DYNAMIC_ALLOCATION > 0 ) */
 
 

--- a/src/tasks.c
+++ b/src/tasks.c
@@ -374,7 +374,7 @@ typedef tskTCB TCB_t;
 /*lint -e956 A manual analysis and inspection has been used to determine which
 static variables must be declared volatile. */
 
-PRIVILEGED_DATA TCB_t * volatile pxCurrentTCB = NULL;
+PRIVILEGED_DATA TCB_t * volatile pxCurrentTCB __attribute__((used)) = NULL;
 
 /* Lists for ready and blocked tasks. --------------------*/
 PRIVILEGED_DATA static List_t pxReadyTasksLists[ configMAX_PRIORITIES ];/*< Prioritised ready tasks. */

--- a/src/variantHooks.cpp
+++ b/src/variantHooks.cpp
@@ -241,3 +241,43 @@ void vApplicationStackOverflowHook( TaskHandle_t xTask __attribute__((unused)), 
 
 #endif /* configCHECK_FOR_STACK_OVERFLOW >= 1 */
 /*-----------------------------------------------------------*/
+
+#if ( configSUPPORT_STATIC_ALLOCATION >= 1 )
+
+void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer,
+                                    StackType_t **ppxIdleTaskStackBuffer,
+                                    uint32_t *pulIdleTaskStackSize ) __attribute__((weak));
+
+void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer,
+                                    StackType_t **ppxIdleTaskStackBuffer,
+                                    uint32_t *pulIdleTaskStackSize )
+{
+    static StaticTask_t xIdleTaskTCB;
+    static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
+
+    *ppxIdleTaskTCBBuffer = &xIdleTaskTCB;
+    *ppxIdleTaskStackBuffer = uxIdleTaskStack;
+    *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
+}
+
+#if ( configUSE_TIMERS >= 1 )
+
+void vApplicationGetTimerTaskMemory( StaticTask_t **ppxTimerTaskTCBBuffer,
+                                     StackType_t **ppxTimerTaskStackBuffer,
+                                     uint32_t *pulTimerTaskStackSize ) __attribute__((weak));
+
+void vApplicationGetTimerTaskMemory( StaticTask_t **ppxTimerTaskTCBBuffer,
+                                     StackType_t **ppxTimerTaskStackBuffer,
+                                     uint32_t *pulTimerTaskStackSize )
+{
+    static StaticTask_t xTimerTaskTCB;
+    static StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
+
+    *ppxTimerTaskTCBBuffer = &xTimerTaskTCB;
+    *ppxTimerTaskStackBuffer = uxTimerTaskStack;
+    *pulTimerTaskStackSize = configTIMER_TASK_STACK_DEPTH;
+}
+
+#endif /* configUSE_TIMERS >= 1 */
+
+#endif /* configSUPPORT_STATIC_ALLOCATION >= 1 */


### PR DESCRIPTION
To have better control of your SRAM, you can use the static `create()` variants. This patch therefore enables `configSUPPORT_STATIC_ALLOCATION`.