### PR TITLE
Fix too small return type for `uxTaskGetStackHighWaterMark()`

### DIFF
--- a/src/FreeRTOSConfig.h
+++ b/src/FreeRTOSConfig.h
@@ -80,6 +80,9 @@
 /* Set the stack pointer type to be uint16_t, otherwise it defaults to unsigned long */
 #define portPOINTER_SIZE_TYPE               uint16_t
 
+/* Set the stack depth type to be uint16_t. */
+#define configSTACK_DEPTH_TYPE              uint16_t
+
 /* Set the following definitions to 1 to include the API function, or zero
 to exclude the API function. */
 

--- a/src/task.h
+++ b/src/task.h
@@ -1420,7 +1420,7 @@ TaskHandle_t xTaskGetHandle( const char *pcNameToQuery ) PRIVILEGED_FUNCTION; /*
  * actual spaces on the stack rather than bytes) since the task referenced by
  * xTask was created.
  */
-uint16_t uxTaskGetStackHighWaterMark( TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
+configSTACK_DEPTH_TYPE uxTaskGetStackHighWaterMark( TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
 
 /* When using trace macros it is sometimes necessary to include task.h before
 FreeRTOS.h.  When this is done TaskHookFunction_t will not yet have been defined,

--- a/src/task.h
+++ b/src/task.h
@@ -1420,7 +1420,7 @@ TaskHandle_t xTaskGetHandle( const char *pcNameToQuery ) PRIVILEGED_FUNCTION; /*
  * actual spaces on the stack rather than bytes) since the task referenced by
  * xTask was created.
  */
-UBaseType_t uxTaskGetStackHighWaterMark( TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
+uint16_t uxTaskGetStackHighWaterMark( TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
 
 /* When using trace macros it is sometimes necessary to include task.h before
 FreeRTOS.h.  When this is done TaskHookFunction_t will not yet have been defined,

--- a/src/task.h
+++ b/src/task.h
@@ -114,7 +114,7 @@ typedef struct xTASK_PARAMETERS
 {
 	TaskFunction_t pvTaskCode;
 	const char * const pcName;	/*lint !e971 Unqualified char types are allowed for strings and single characters only. */
-	uint16_t usStackDepth;
+	configSTACK_DEPTH_TYPE usStackDepth;
 	void *pvParameters;
 	UBaseType_t uxPriority;
 	StackType_t *puxStackBuffer;

--- a/src/tasks.c
+++ b/src/tasks.c
@@ -3642,11 +3642,11 @@ static void prvCheckTasksWaitingTermination( void )
 
 #if ( INCLUDE_uxTaskGetStackHighWaterMark == 1 )
 
-	UBaseType_t uxTaskGetStackHighWaterMark( TaskHandle_t xTask )
+	uint16_t uxTaskGetStackHighWaterMark( TaskHandle_t xTask )
 	{
 	TCB_t *pxTCB;
 	uint8_t *pucEndOfStack;
-	UBaseType_t uxReturn;
+	uint16_t uxReturn;
 
 		pxTCB = prvGetTCBFromHandle( xTask );
 
@@ -3660,7 +3660,7 @@ static void prvCheckTasksWaitingTermination( void )
 		}
 		#endif
 
-		uxReturn = ( UBaseType_t ) prvTaskCheckFreeStackSpace( pucEndOfStack );
+		uxReturn = prvTaskCheckFreeStackSpace( pucEndOfStack );
 
 		return uxReturn;
 	}

--- a/src/tasks.c
+++ b/src/tasks.c
@@ -3622,7 +3622,7 @@ static void prvCheckTasksWaitingTermination( void )
 
 #if ( ( configUSE_TRACE_FACILITY == 1 ) || ( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) )
 
-	static uint16_t prvTaskCheckFreeStackSpace( const uint8_t * pucStackByte )
+	static configSTACK_DEPTH_TYPE prvTaskCheckFreeStackSpace( const uint8_t * pucStackByte )
 	{
 	uint32_t ulCount = 0U;
 
@@ -3634,7 +3634,7 @@ static void prvCheckTasksWaitingTermination( void )
 
 		ulCount /= ( uint32_t ) sizeof( StackType_t ); /*lint !e961 Casting is not redundant on smaller architectures. */
 
-		return ( uint16_t ) ulCount;
+		return ( configSTACK_DEPTH_TYPE ) ulCount;
 	}
 
 #endif /* ( ( configUSE_TRACE_FACILITY == 1 ) || ( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) ) */
@@ -3642,11 +3642,11 @@ static void prvCheckTasksWaitingTermination( void )
 
 #if ( INCLUDE_uxTaskGetStackHighWaterMark == 1 )
 
-	uint16_t uxTaskGetStackHighWaterMark( TaskHandle_t xTask )
+	configSTACK_DEPTH_TYPE uxTaskGetStackHighWaterMark( TaskHandle_t xTask )
 	{
 	TCB_t *pxTCB;
 	uint8_t *pucEndOfStack;
-	uint16_t uxReturn;
+	configSTACK_DEPTH_TYPE uxReturn;
 
 		pxTCB = prvGetTCBFromHandle( xTask );
 

--- a/src/tasks.c
+++ b/src/tasks.c
@@ -658,7 +658,7 @@ static void prvAddNewTaskToReadyList( TCB_t *pxNewTCB ) PRIVILEGED_FUNCTION;
 
 			prvInitialiseNewTask(	pxTaskDefinition->pvTaskCode,
 									pxTaskDefinition->pcName,
-									( uint32_t ) pxTaskDefinition->usStackDepth,
+									pxTaskDefinition->usStackDepth,
 									pxTaskDefinition->pvParameters,
 									pxTaskDefinition->uxPriority,
 									pxCreatedTask, pxNewTCB,
@@ -706,7 +706,7 @@ static void prvAddNewTaskToReadyList( TCB_t *pxNewTCB ) PRIVILEGED_FUNCTION;
 
 				prvInitialiseNewTask(	pxTaskDefinition->pvTaskCode,
 										pxTaskDefinition->pcName,
-										( uint32_t ) pxTaskDefinition->usStackDepth,
+										pxTaskDefinition->usStackDepth,
 										pxTaskDefinition->pvParameters,
 										pxTaskDefinition->uxPriority,
 										pxCreatedTask, pxNewTCB,


### PR DESCRIPTION
This PR fixes #27 by replacing the `uint8_t` return type of `uxTaskGetStackHighWaterMark()` with `uint16_t`.