### PR TITLE
Allow disable idle hook without modify code.

### DIFF
--- a/src/FreeRTOSConfig.h
+++ b/src/FreeRTOSConfig.h
@@ -44,7 +44,12 @@
 
 // And on to the things the same no matter the AVR type...
 #define configUSE_PREEMPTION                1
-#define configUSE_IDLE_HOOK                 1
+
+// Define configUSE_IDLE_HOOK
+#ifndef configUSE_IDLE_HOOK
+    #define configUSE_IDLE_HOOK             1
+#endif
+
 #define configUSE_TICK_HOOK                 0
 #define configCPU_CLOCK_HZ                  ( ( uint32_t ) F_CPU )          // This F_CPU variable set by the environment
 #define configMAX_PRIORITIES                4

--- a/src/variantHooks.cpp
+++ b/src/variantHooks.cpp
@@ -77,6 +77,8 @@ void vApplicationIdleHook( void )
     if (serialEventRun) serialEventRun();
 }
 
+#else
+    void loop() {} //Empty loop function
 #endif /* configUSE_IDLE_HOOK == 1 */
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
It allows to assign a value for `configUSE_IDLE_HOOK` property to disable idle hook if don't use it.
For example, using Platform.io project configuration.

```python
[env:uno]
platform = atmelavr
board = uno
framework = arduino

build_flags =
  -DconfigUSE_IDLE_HOOK=0
```