### PR TITLE
Add travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+
+cache:
+  directories:
+    - "~/.platformio"
+
+install:
+  - pip install -U platformio
+  - platformio update
+
+script:
+  - platformio ci --lib="." --board=uno --board=leonardo --board=sanguino_atmega1284p --board=megaatmega2560 examples/AnalogRead_DigitalRead/AnalogRead_DigitalRead.ino
+  - platformio ci --lib="." --board=uno --board=leonardo --board=sanguino_atmega1284p --board=megaatmega2560 examples/Blink_AnalogRead/Blink_AnalogRead.ino
+  - platformio ci --lib="." --board=uno --board=leonardo --board=sanguino_atmega1284p --board=megaatmega2560 examples/TaskUtilities/TaskUtilities.ino


### PR DESCRIPTION
This PR allow to use [Travis](https://travis-ci.org/) and [PlatformIO Continuous Integration support](https://docs.platformio.org/en/latest/integration/ci/index.html) to check in this repo or in a fork if library code and examples compile after a change.

Example: https://travis-ci.org/github/hectorespert/Arduino_FreeRTOS_Library/builds/679485252


