### PR TITLE
Enable configASSERT macro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ script:
   - platformio ci --lib="." --board=uno --board=leonardo --board=sanguino_atmega1284p --board=megaatmega2560 examples/AnalogRead_DigitalRead/AnalogRead_DigitalRead.ino
   - platformio ci --lib="." --board=uno --board=leonardo --board=sanguino_atmega1284p --board=megaatmega2560 examples/Blink_AnalogRead/Blink_AnalogRead.ino
   - platformio ci --lib="." --board=uno --board=leonardo --board=sanguino_atmega1284p --board=megaatmega2560 examples/TaskUtilities/TaskUtilities.ino
+  - platformio ci --lib="." --board=uno --board=leonardo --board=sanguino_atmega1284p --board=megaatmega2560 examples/Assert/Assert.ino

--- a/examples/Assert/Assert.ino
+++ b/examples/Assert/Assert.ino
@@ -1,0 +1,24 @@
+/*
+ * Example of FreeRTOS configASSERT macro
+ * https://www.freertos.org/a00110.html#configASSERT
+ */
+
+#include <Arduino_FreeRTOS.h>
+
+const boolean valueToAssert = true;
+
+// The setup function runs once when you press reset or power the board
+void setup() {
+
+  // Assert value is true, execution doesn't stop.
+  configASSERT(valueToAssert == true);
+
+  // Assert value is false, FreeRTOS execution stops and start to blink main led two times with 4 second cycle.
+  configASSERT(valueToAssert == false);
+}
+    
+
+void loop()
+{
+  // Empty. Things are done in Tasks.
+}

--- a/src/FreeRTOSConfig.h
+++ b/src/FreeRTOSConfig.h
@@ -106,4 +106,28 @@ to exclude the API function. */
 #define configMAX(a,b)  ({ __typeof__ (a) _a = (a); __typeof__ (b) _b = (b); _a > _b ? _a : _b; })
 #define configMIN(a,b)  ({ __typeof__ (a) _a = (a); __typeof__ (b) _b = (b); _a < _b ? _a : _b; })
 
+/**
+ * configASSERT macro: https://www.freertos.org/a00110.html#configASSERT
+ */
+#ifndef configASSERT
+    /**
+     * Enable configASSERT macro by default if it is not defined.
+     */
+    #ifndef configDEFAULT_ASSERT
+        #define configDEFAULT_ASSERT 1
+    #endif
+
+    /**
+     * Define a hook method for configASSERT macro if configASSERT is enabled.
+     */
+    #if configDEFAULT_ASSERT == 1
+        extern void vApplicationAssertHook();
+        #define configASSERT( x ) if (( x ) == 0) { vApplicationAssertHook(); }
+    #endif
+
+#else
+    #define configDEFAULT_ASSERT 0
+#endif
+
+
 #endif /* FREERTOS_CONFIG_H */

--- a/src/variantHooks.cpp
+++ b/src/variantHooks.cpp
@@ -159,9 +159,7 @@ void vApplicationMallocFailedHook( void )
     for(;;)
     {
         _delay_ms(50);
-
         prvBlinkMainLed(); // Main LED fast blink.
-
     }
 }
 
@@ -257,15 +255,13 @@ void vApplicationAssertHook() {
         prvBlinkMainLed(); // Led off.
 
         _delay_ms(2000);
-        
-        prvBlinkMainLed(); // Led on.
-        _delay_ms(100);
-
-        prvBlinkMainLed(); // Lef off
-        _delay_ms(100);
-        
         prvBlinkMainLed(); // Led on.
 
+        _delay_ms(100);
+        prvBlinkMainLed(); // Led off
+
+        _delay_ms(100);
+        prvBlinkMainLed(); // Led on.
     }
 }
 #endif

--- a/src/variantHooks.cpp
+++ b/src/variantHooks.cpp
@@ -82,6 +82,57 @@ void vApplicationIdleHook( void )
 #endif /* configUSE_IDLE_HOOK == 1 */
 /*-----------------------------------------------------------*/
 
+#if ( configUSE_MALLOC_FAILED_HOOK == 1 || configCHECK_FOR_STACK_OVERFLOW >= 1 || configDEFAULT_ASSERT == 1 )
+
+/**
+ * Private function to enable board led to use it in application hooks
+ */
+void prvSetMainLedOn( void ) 
+{
+
+#if defined(__AVR_ATmega640__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__) // Arduino Mega with 2560
+    DDRB  |= _BV(DDB7);
+    PORTB |= _BV(PORTB7);       // Main (red PB7) LED on. Main LED on.
+
+#elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega1284PA__) // Seeed Goldilocks with 1284p
+    DDRB  |= _BV(DDB7);
+    PORTB |= _BV(PORTB7);       // Main (red PB7) LED on. Main LED on.
+
+#elif defined(__AVR_ATmega328P__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega8__) // assume we're using an Arduino Uno with 328p
+    DDRB  |= _BV(DDB5);
+    PORTB |= _BV(PORTB5);       // Main (red PB5) LED on. Main LED on.
+
+#elif defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega16U4__) // assume we're using an Arduino Leonardo with 32u4
+    DDRC  |= _BV(DDC7);
+    PORTC |= _BV(PORTC7);       // Main (red PC7) LED on. Main LED on.
+
+#endif
+
+}
+
+/**
+ * Private function to blink board led to use it in application hooks
+ */
+void prvBlinkMainLed( void ) 
+{
+
+#if defined(__AVR_ATmega640__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__)  // Mega with 2560
+        PINB  |= _BV(PINB7);       // Main (red PB7) LED toggle.
+
+#elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega1284PA__) // Seeed Goldilocks with 1284p
+        PINB  |= _BV(PINB7);       // Main (red PB7) LED toggle.
+
+#elif defined(__AVR_ATmega328P__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega8__) // assume we're using an Arduino Uno with 328p
+        PINB  |= _BV(PINB5);       // Main (red PB5) LED toggle.
+
+#elif defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega16U4__) // assume we're using an Arduino Leonardo with 32u4
+        PINC  |= _BV(PINC7);       // Main (red PC7) LED toggle.
+
+#endif
+
+}
+
+#endif
 
 #if ( configUSE_MALLOC_FAILED_HOOK == 1 )
 /*---------------------------------------------------------------------------*\
@@ -103,41 +154,13 @@ void vApplicationMallocFailedHook( void ) __attribute__((weak));
 
 void vApplicationMallocFailedHook( void )
 {
-#if defined(__AVR_ATmega640__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__) // Arduino Mega with 2560
-    DDRB  |= _BV(DDB7);
-    PORTB |= _BV(PORTB7);       // Main (red PB7) LED on. Main LED on.
-
-#elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega1284PA__) // Seeed Goldilocks with 1284p
-    DDRB  |= _BV(DDB7);
-    PORTB |= _BV(PORTB7);       // Main (red PB7) LED on. Main LED on.
-
-#elif defined(__AVR_ATmega328P__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega8__) // assume we're using an Arduino Uno with 328p
-    DDRB  |= _BV(DDB5);
-    PORTB |= _BV(PORTB5);       // Main (red PB5) LED on. Main LED on.
-
-#elif defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega16U4__) // assume we're using an Arduino Leonardo with 32u4
-    DDRC  |= _BV(DDC7);
-    PORTC |= _BV(PORTC7);       // Main (red PC7) LED on. Main LED on.
-
-#endif
-
+    prvSetMainLedOn(); // Main LED on.
+    
     for(;;)
     {
         _delay_ms(50);
 
-#if defined(__AVR_ATmega640__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__)  // Mega with 2560
-        PINB  |= _BV(PINB7);       // Main (red PB7) LED toggle. Main LED fast blink.
-
-#elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega1284PA__) // Seeed Goldilocks with 1284p
-        PINB  |= _BV(PINB7);       // Main (red PB7) LED toggle. Main LED fast blink.
-
-#elif defined(__AVR_ATmega328P__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega8__) // assume we're using an Arduino Uno with 328p
-        PINB  |= _BV(PINB5);       // Main (red PB5) LED toggle. Main LED fast blink.
-
-#elif defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega16U4__) // assume we're using an Arduino Leonardo with 32u4
-        PINC  |= _BV(PINC7);       // Main (red PC7) LED toggle. Main LED fast blink.
-
-#endif
+        prvBlinkMainLed(); // Main LED fast blink.
 
     }
 }
@@ -166,42 +189,12 @@ void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName ) __att
 
 void vApplicationStackOverflowHook( TaskHandle_t xTask __attribute__((unused)), char *pcTaskName __attribute__((unused)) )
 {
-#if defined(__AVR_ATmega640__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__)  // Arduino Mega with 2560
-    DDRB  |= _BV(DDB7);
-    PORTB |= _BV(PORTB7);       // Main (red PB7) LED on. Main LED on.
-
-#elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega1284PA__) // Seeed Goldilocks with 1284p
-    DDRB  |= _BV(DDB7);
-    PORTB |= _BV(PORTB7);       // Main (red PB7) LED on. Main LED on.
-
-#elif defined(__AVR_ATmega328P__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega8__) // assume we're using an Arduino Uno with 328p
-    DDRB  |= _BV(DDB5);
-    PORTB |= _BV(PORTB5);       // Main (red PB5) LED on. Main LED on.
-
-#elif defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega16U4__) // assume we're using an Arduino Leonardo with 32u4
-    DDRC  |= _BV(DDC7);
-    PORTC |= _BV(PORTC7);       // Main (red PC7) LED on. Main LED on.
-
-#endif
+    prvSetMainLedOn(); // Main LED on.
 
     for(;;)
     {
         _delay_ms(2000);
-
-#if defined(__AVR_ATmega640__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega2561__)  // Arduino Mega with 2560
-        PINB  |= _BV(PINB7);       // Main (red PB7) LED toggle. Main LED slow blink.
-
-#elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega1284PA__) // Seeed Goldilocks with 1284p
-        PINB  |= _BV(PINB7);       // Main (red PB7) LED toggle. Main LED slow blink.
-
-#elif defined(__AVR_ATmega328P__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega8__) // assume we're using an Arduino Uno with 328p
-        PINB  |= _BV(PINB5);       // Main (red PB5) LED toggle. Main LED slow blink.
-
-#elif defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega16U4__) // assume we're using an Arduino Leonardo with 32u4
-        PINC  |= _BV(PINC7);       // Main (red PC7) LED toggle. Main LED slow blink.
-
-#endif
-
+        prvBlinkMainLed();  // Main LED slow blink.
     }
 }
 
@@ -247,3 +240,32 @@ void vApplicationGetTimerTaskMemory( StaticTask_t **ppxTimerTaskTCBBuffer,
 #endif /* configUSE_TIMERS >= 1 */
 
 #endif /* configSUPPORT_STATIC_ALLOCATION >= 1 */
+
+/**
+ * configASSERT default implementation
+ */
+#if configDEFAULT_ASSERT == 1
+
+void vApplicationAssertHook() {
+
+    taskDISABLE_INTERRUPTS(); // Disable task interrupts
+
+    prvSetMainLedOn(); // Main LED on.
+    for(;;)
+    {
+        _delay_ms(100);
+        prvBlinkMainLed(); // Led off.
+
+        _delay_ms(2000);
+        
+        prvBlinkMainLed(); // Led on.
+        _delay_ms(100);
+
+        prvBlinkMainLed(); // Lef off
+        _delay_ms(100);
+        
+        prvBlinkMainLed(); // Led on.
+
+    }
+}
+#endif


### PR DESCRIPTION
- Enable [configASSERT macro](https://www.freertos.org/a00110.html#configASSERT) by default in Arduino FreeRTOS library.
- Add a default implementation to blink main led if an assertion fails.