### PR TITLE
Add keywords.txt for Syntax Coloring

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,0 +1,31 @@
+# Syntax Coloring Map For FreeRTOS
+# https://arduino.github.io/arduino-cli/library-specification/#keywords
+# Formatted by a single true tab (not spaces)
+
+# Datatypes (KEYWORD1)
+SemaphoreHandle_t	KEYWORD1
+QueueHandle_t	KEYWORD1
+TaskHandle_t	KEYWORD1
+
+# Methods and Functions (KEYWORD2)
+xSemaphoreCreateMutex	KEYWORD2
+xSemaphoreCreateBinary	KEYWORD2
+xSemaphoreGive	KEYWORD2
+xSemaphoreGiveFromISR	KEYWORD2
+xTaskCreate	KEYWORD2
+vTaskDelay	KEYWORD2
+xQueueCreate	KEYWORD2
+xQueueSend	KEYWORD2
+pcTaskGetName KEYWORD2
+ulTaskNotifyTake	KEYWORD2
+vTaskNotifyGiveFromISR	KEYWORD2
+taskYIELD	KEYWORD2
+vTaskSuspend	KEYWORD2
+vTaskResume	KEYWORD2
+xTaskGetTickCount	KEYWORD2
+uxTaskGetNumberOfTasks	KEYWORD2
+uxTaskGetStackHighWaterMark	KEYWORD2
+
+# Instances (KEYWORD2)
+
+# Constants (LITERAL1)


### PR DESCRIPTION
Add `keywords.txt` file to enable [Arduino IDE Syntax Coloring](https://arduino.github.io/arduino-cli/library-specification/#keywords) for FreeRTOS library