### PR TITLE
Added vTaskDelay to TaskLed Function

### DIFF
--- a/examples/Interrupts/Interrupts.ino
+++ b/examples/Interrupts/Interrupts.ino
@@ -73,6 +73,6 @@ void TaskLed(void *pvParameters)
     if (xSemaphoreTake(interruptSemaphore, portMAX_DELAY) == pdPASS) {
       digitalWrite(LED_BUILTIN, !digitalRead(LED_BUILTIN));
     }
-    
+    vTaskDelay(10);
   }
 }


### PR DESCRIPTION
Without Delay, digitalWrite and digitalRead looks like skipped
@feilipu  Please Merge my pull request to your repository. 
I tried the code without delay Arduino Board misbehaved hence I added the Delay, It worked Fine