### PR TITLE
Support of the LGT8F328 MCU using Timer 3 for tick generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Ignore .development file, https://arduino.github.io/arduino-cli/library-specification/#development-flag-file
 .development
+
+.DS_Store
+Icon

--- a/doc/tick_sources_lgt_timer3.cpp
+++ b/doc/tick_sources_lgt_timer3.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <lgtx8p.h>    // lgt8f328p spec
 #include <FreeRTOSVariant.h>
 
 /*

--- a/doc/tick_sources_lgt_timer3.cpp
+++ b/doc/tick_sources_lgt_timer3.cpp
@@ -1,0 +1,100 @@
+/*
+ * Code tu use the LGT8F328 16 bit Timer 3 as a scheduler tick source
+ * in Arduino_FreeRTOS.
+ *
+ * gpb01 - Aug 2023
+ *
+ */
+
+#include <FreeRTOSVariant.h>
+
+/*
+ * Formula for the frequency is:
+ *      f = F_CPU / (PRESCALER * (1 + COUNTER_TOP)
+ *
+ */
+
+#define PRESCALER               8UL
+
+#if ( F_CPU == 32000000UL )
+    // Assuming the MCU clock of 32MHz, Timer 3 is 16 bits, prescaler 8 and counter top 63998, the resulting tick period is 16 ms (62.5 Hz).
+    #define TICK_PERIOD_16MS    63998UL
+#elif ( F_CPU == 16000000UL )
+    // Assuming the MCU clock of 16MHz, Timer 3 is 16 bits, prescaler 8 and counter top 31999, the resulting tick period is 16 ms (62.5 Hz).
+    #define TICK_PERIOD_16MS    31999UL
+#elif ( F_CPU == 8000000UL )
+    // Assuming the MCU clock of  8MHz, Timer 3 is 16 bits, prescaler 8 and counter top 15999, the resulting tick period is 16 ms (62.5 Hz).
+    #define TICK_PERIOD_16MS    15999UL
+#else   
+    #error "Unsupported MCU frequency."
+#endif // F_CPU options
+
+#if (portTICK_PERIOD_MS != (PRESCALER * (1 + TICK_PERIOD_16MS) * 1000 / F_CPU))
+    #warning portTICK_PERIOD_MS defined in FreeRTOSVariant.h differs from your timer configuration
+#endif
+
+#define MODE_CTC          (1 << WGM32)
+#define PRESCALER_8       (1 << CS31)
+#define INTERRUPT_OCMA    (1 << OCIE3A)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    void prvSetupTimerInterrupt( void )
+    {
+        cli();
+        TCCR3A = 0;
+        TCCR3B = 0;
+        TCNT3  = 0;
+        // Now configure the timer:
+        OCR3A = TICK_PERIOD_16MS;
+        // CTC
+        TCCR3B |= MODE_CTC;
+        // Prescaler 8
+        TCCR3B |= PRESCALER_8;
+        // Output Compare Match A Interrupt Enable
+        TIMSK3 |= INTERRUPT_OCMA;
+        // Prevent missing the top and going into a possibly long wait until wrapping around:
+        TCNT3 = 0;
+        // At this point the global interrupt flag is NOT YET enabled,
+        // so you're NOT starting to get the ISR calls until FreeRTOS enables it just before launching the scheduler.
+    }
+	
+	
+	void vPortEndScheduler( void )
+	{
+	    cli();              /* disable interrupts */
+	    TIMSK3 &= ~( INTERRUPT_OCMA );
+	    sei();              /* enable interrupts  */
+	}
+	
+        
+#if configUSE_PREEMPTION == 1
+    
+    ISR(TIMER3_vect, ISR_NAKED) __attribute__ ((hot, flatten))
+	{
+        if (TIFR3 & (1 << OCF3A)) {
+            TIFR3 = 1 << OCF3A;
+            /* on OCR3A match */
+            vPortYieldFromTick();
+            __asm__ __volatile__ ( "reti" );
+        }
+    }
+
+#else
+    
+    ISR(TIMER3_vect) __attribute__ ((hot, flatten))
+	{
+        if (TIFR3 & (1 << OCF3A)) {
+            TIFR3 = 1 << OCF3A;
+            /* on OCR3A match */
+            xTaskIncrementTick();
+        }
+    }
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/FreeRTOSVariant.h
+++ b/src/FreeRTOSVariant.h
@@ -54,15 +54,17 @@ extern "C" {
                                 WDTO_1S
                                 WDTO_2S
 */
-	
+
+   
 // #define portUSE_LGT_TIMER3                  // portUSE_LGT_TIMER3 uncomment to use the 16 bit Timer 3 (on LGT8F328 MCU) for xTaskIncrementTick
 
+
 #if defined( portUSE_LGT_TIMER3 )
-	
+   
     #if defined( portUSE_WDTO )
         #undef portUSE_WDTO
     #endif
-	
+   
     // Formula for the frequency is: f = F_CPU / (PRESCALER * (1 + COUNTER_TOP))
     #define PRESCALER           8
 
@@ -75,24 +77,24 @@ extern "C" {
     #elif ( F_CPU == 8000000UL )
         // Assuming the MCU clock of  8MHz, Timer 3 is 16 bits, prescaler 8 and counter top 15001, the resulting tick period is 15 ms (66.66 Hz).
         #define TICK_PERIOD_15MS    15001UL
-    #else	
+    #else   
         #error "Unsupported MCU frequency."
     #endif // F_CPU options
 
     #define configTICK_RATE_HZ  ( (TickType_t) ( F_CPU / (uint32_t) ( PRESCALER * ( 1 + TICK_PERIOD_15MS ) ) ) )
-    #define portTICK_PERIOD_MS  ( (TickType_t) ( 1000 / configTICK_RATE_HZ ) )	
+    #define portTICK_PERIOD_MS  ( (TickType_t) ( 1000 / configTICK_RATE_HZ ) )   
 
 #elif defined( portUSE_WDTO )
 
     #define configTICK_RATE_HZ  ( (TickType_t)( (uint32_t)128000 >> (portUSE_WDTO + 11) ) )  // 2^11 = 2048 WDT scaler for 128kHz Timer
     #define portTICK_PERIOD_MS  ( (TickType_t) _BV( portUSE_WDTO + 4 ) )
-	
+   
 #else
-	
+   
     #warning "Variant configuration must define `configTICK_RATE_HZ` and `portTICK_PERIOD_MS` as either a macro or a constant"
     #define configTICK_RATE_HZ  1
     #define portTICK_PERIOD_MS  ( (TickType_t) 1000 / configTICK_RATE_HZ )
-	
+   
 #endif
 
 /*-----------------------------------------------------------*/

--- a/src/FreeRTOSVariant.h
+++ b/src/FreeRTOSVariant.h
@@ -21,6 +21,9 @@
  *
  * This file is NOT part of the FreeRTOS distribution.
  *
+ * Updated on Aug 2023 by gpb01 to add the capability to use the 16 bit Timer 3
+ * on LGT8F328 MCU for xTaskIncrementTick.
+ *
  */
 
 #ifndef freeRTOSVariant_h
@@ -51,15 +54,45 @@ extern "C" {
                                 WDTO_1S
                                 WDTO_2S
 */
+	
+// #define portUSE_LGT_TIMER3                  // portUSE_LGT_TIMER3 uncomment to use the 16 bit Timer 3 (on LGT8F328 MCU) for xTaskIncrementTick
 
-#if defined( portUSE_WDTO )
+#if defined( portUSE_LGT_TIMER3 )
+	
+    #if defined( portUSE_WDTO )
+        #undef portUSE_WDTO
+    #endif
+	
+    // Formula for the frequency is: f = F_CPU / (PRESCALER * (1 + COUNTER_TOP))
+    #define PRESCALER           8
+
+    #if ( F_CPU == 32000000UL )
+        // Assuming the MCU clock of 32MHz, Timer 3 is 16 bits, prescaler 8 and counter top 60004, the resulting tick period is 15 ms (66.66 Hz).
+        #define TICK_PERIOD_15MS    60004UL
+    #elif ( F_CPU == 16000000UL )
+        // Assuming the MCU clock of 16MHz, Timer 3 is 16 bits, prescaler 8 and counter top 30002, the resulting tick period is 15 ms (66.66 Hz).
+        #define TICK_PERIOD_15MS    30002UL
+    #elif ( F_CPU == 8000000UL )
+        // Assuming the MCU clock of  8MHz, Timer 3 is 16 bits, prescaler 8 and counter top 15001, the resulting tick period is 15 ms (66.66 Hz).
+        #define TICK_PERIOD_15MS    15001UL
+    #else	
+        #error "Unsupported MCU frequency."
+    #endif // F_CPU options
+
+    #define configTICK_RATE_HZ  ( (TickType_t) ( F_CPU / (uint32_t) ( PRESCALER * ( 1 + TICK_PERIOD_15MS ) ) ) )
+    #define portTICK_PERIOD_MS  ( (TickType_t) ( 1000 / configTICK_RATE_HZ ) )	
+
+#elif defined( portUSE_WDTO )
 
     #define configTICK_RATE_HZ  ( (TickType_t)( (uint32_t)128000 >> (portUSE_WDTO + 11) ) )  // 2^11 = 2048 WDT scaler for 128kHz Timer
     #define portTICK_PERIOD_MS  ( (TickType_t) _BV( portUSE_WDTO + 4 ) )
+	
 #else
+	
     #warning "Variant configuration must define `configTICK_RATE_HZ` and `portTICK_PERIOD_MS` as either a macro or a constant"
     #define configTICK_RATE_HZ  1
     #define portTICK_PERIOD_MS  ( (TickType_t) 1000 / configTICK_RATE_HZ )
+	
 #endif
 
 /*-----------------------------------------------------------*/

--- a/src/port.c
+++ b/src/port.c
@@ -51,13 +51,25 @@
 #define portFLAGS_INT_ENABLED           ( (StackType_t) 0x80 )
 
 #if defined( portUSE_WDTO )
+
     #define portSCHEDULER_ISR           WDT_vect
 
 #elif defined( portUSE_LGT_TIMER3 )
 
+    #define portSCHEDULER_ISR           TIMER3_vect
 
 #else
+
     #warning "The user must define a Timer to be used for the Scheduler."
+
+#endif
+
+/*-----------------------------------------------------------*/
+
+#if defined( portUSE_WDTO )
+#warning "Note: You are compiling Arduino_FreeRTOS library for an AVR MCU using WDT."
+#elif defined( portUSE_LGT_TIMER3 )
+#warning "Note: You are compiling Arduino_FreeRTOS library for LGT8F328 MCU using Timer 3."
 #endif
 
 /*-----------------------------------------------------------*/
@@ -815,13 +827,13 @@ extern void prvSetupTimerInterrupt( void );
         vPortYieldFromTick();
         __asm__ __volatile__ ( "reti" );
     }
-	 	 
-	 #elif defined( portUSE_LGT_TIMER3 )
-	 	 
-    ISR(TIMER3_vect, ISR_NAKED) __attribute__ ((hot, flatten));
+         
+     #elif defined( portUSE_LGT_TIMER3 )
+         
+    ISR(portSCHEDULER_ISR, ISR_NAKED) __attribute__ ((hot, flatten));
 /*  ISR(portSCHEDULER_ISR, ISR_NAKED ISR_NOBLOCK) __attribute__ ((hot, flatten));
  */
-    ISR(TIMER3_vect)
+    ISR(portSCHEDULER_ISR)
     {
         if (TIFR3 & (1 << OCF3A)) {
             TIFR3 = 1 << OCF3A;
@@ -830,11 +842,11 @@ extern void prvSetupTimerInterrupt( void );
             __asm__ __volatile__ ( "reti" );
         }
     }
-	  
-	 #else
+      
+     #else
          #warning "The user is responsible to provide the corrcet statements for the ISR"
-	 #endif 
-	 
+     #endif 
+     
 #else
 
     /*
@@ -844,9 +856,9 @@ extern void prvSetupTimerInterrupt( void );
      *
      * use ISR_NOBLOCK where there is an important timer running, that should preempt the scheduler.
      */
-	 
-	 #if defined( portUSE_WDTO )
-	 
+     
+     #if defined( portUSE_WDTO )
+     
     ISR(portSCHEDULER_ISR) __attribute__ ((hot, flatten));
 /*  ISR(portSCHEDULER_ISR, ISR_NOBLOCK) __attribute__ ((hot, flatten));
  */
@@ -854,23 +866,23 @@ extern void prvSetupTimerInterrupt( void );
     {
         xTaskIncrementTick();
     }
-	 
-	 #elif defined( portUSE_LGT_TIMER3 )
-	 
-    ISR(TIMER3_vect) __attribute__ ((hot, flatten));
+     
+     #elif defined( portUSE_LGT_TIMER3 )
+     
+    ISR(portSCHEDULER_ISR) __attribute__ ((hot, flatten));
 /*  ISR(portSCHEDULER_ISR, ISR_NOBLOCK) __attribute__ ((hot, flatten));
  */
-    ISR(TIMER3_vect)
-	 {
+    ISR(portSCHEDULER_ISR)
+     {
         if (TIFR3 & (1 << OCF3A)) {
             TIFR3 = 1 << OCF3A;
             /* on OCR3A match */
             xTaskIncrementTick();
         }
-	 }
-	 
+     }
+     
     #else
         #warning "The user is responsible to provide the corrcet statements for the ISR"
     #endif
-	 
+     
 #endif

--- a/src/port.c
+++ b/src/port.c
@@ -24,8 +24,10 @@
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
  *
+ * Updated on Aug 2023 by gpb01 to add the capability to use the 16 bit Timer 3
+ * on LGT8F328 MCU for xTaskIncrementTick.
+ *
  */
-
 
 #include <stdlib.h>
 
@@ -37,6 +39,10 @@
 #include "Arduino_FreeRTOS.h"
 #include "task.h"
 
+#if defined( portUSE_LGT_TIMER3 )
+#include <lgtx8p.h>    // lgt8f328p spec
+#endif
+
 /*-----------------------------------------------------------
  * Implementation of functions defined in portable.h for the AVR port.
  *----------------------------------------------------------*/
@@ -46,6 +52,9 @@
 
 #if defined( portUSE_WDTO )
     #define portSCHEDULER_ISR           WDT_vect
+
+#elif defined( portUSE_LGT_TIMER3 )
+
 
 #else
     #warning "The user must define a Timer to be used for the Scheduler."
@@ -617,8 +626,18 @@ void vPortEndScheduler( void )
 {
     /* It is unlikely that the ATmega port will get stopped.  If required simply
      * disable the tick interrupt here. */
-
+   
+#if defined( portUSE_WDTO )
+   
     wdt_disable();      /* disable Watchdog Timer */
+    
+#elif defined( portUSE_LGT_TIMER3 )
+    
+    cli();              /* disable interrupts */
+    TIMSK3 &= ~(1 << OCIE3A);
+    sei();              /* enable interrupts  */
+    
+#endif
 }
 /*-----------------------------------------------------------*/
 
@@ -638,7 +657,7 @@ void vPortEndScheduler( void )
 
 extern void delay ( unsigned long ms );
 
-#if defined( portUSE_WDTO )
+#if defined( portUSE_WDTO ) || defined( portUSE_LGT_TIMER3 )
 void vPortDelay( const uint32_t ms ) __attribute__ ((hot, flatten));
 void vPortDelay( const uint32_t ms )
 {
@@ -700,9 +719,15 @@ void vPortYieldFromTick( void )
 {
     portSAVE_CONTEXT();
     sleep_reset();        /* reset the sleep_mode() faster than sleep_disable(); */
+    
+/*
+       
 #if defined(__LGT8FX8P__) || defined(__LGT8FX8E__) || defined(__LGT8FX8P48__)
-    wdt_reset();        /* Logic Green requires the WDT be reset when it expires */
+    wdt_reset();        // Logic Green requires the WDT be reset when it expires
 #endif
+    
+*/
+    
     if( xTaskIncrementTick() != pdFALSE )
     {
         vTaskSwitchContext();
@@ -714,6 +739,7 @@ void vPortYieldFromTick( void )
 /*-----------------------------------------------------------*/
 
 #if defined( portUSE_WDTO )
+
 /*
  * Setup WDT to generate a tick interrupt.
  */
@@ -721,8 +747,9 @@ void prvSetupTimerInterrupt( void )
 {
     /* reset watchdog */
     wdt_reset();
+    
+/*
 
-    /* set up WDT Interrupt (rather than the WDT Reset). */
 #if defined(__LGT8FX8P__) || defined(__LGT8FX8E__) || defined(__LGT8FX8P48__)
     wdt_ienable( portUSE_WDTO );
 #else
@@ -730,9 +757,40 @@ void prvSetupTimerInterrupt( void )
 #endif
 }
 
+*/
+    wdt_interrupt_enable( portUSE_WDTO );
+}
+
+#elif defined( portUSE_LGT_TIMER3 )
+
+/*
+ * Setup 16 bit Timer 3 (on LGT8F328 MCU) to generate a tick interrupt.
+ */
+void prvSetupTimerInterrupt( void )
+{
+    cli();
+    TCCR3A = 0;
+    TCCR3B = 0;
+    TCNT3  = 0;
+    // Now configure the timer:
+    OCR3A = TICK_PERIOD_15MS;
+    // CTC
+    TCCR3B |= (1 << WGM32);
+    // Prescaler 8
+    TCCR3B |= (1 << CS31);
+    // Output Compare Match A Interrupt Enable
+    TIMSK3 |= (1 << OCIE3A);
+    // Prevent missing the top and going into a possibly long wait until wrapping around:
+    TCNT3 = 0;
+    // At this point the global interrupt flag is NOT YET enabled,
+    // so you're NOT starting to get the ISR calls until FreeRTOS enables it just before launching the scheduler.
+}
+
 #else
+
 #warning "The user is responsible to provide function `prvSetupTimerInterrupt()`"
 extern void prvSetupTimerInterrupt( void );
+
 #endif
 
 /*-----------------------------------------------------------*/
@@ -747,6 +805,8 @@ extern void prvSetupTimerInterrupt( void );
      * use ISR_NOBLOCK where there is an important timer running, that should preempt the scheduler.
      *
      */
+    #if defined( portUSE_WDTO )
+
     ISR(portSCHEDULER_ISR, ISR_NAKED) __attribute__ ((hot, flatten));
 /*  ISR(portSCHEDULER_ISR, ISR_NAKED ISR_NOBLOCK) __attribute__ ((hot, flatten));
  */
@@ -755,6 +815,26 @@ extern void prvSetupTimerInterrupt( void );
         vPortYieldFromTick();
         __asm__ __volatile__ ( "reti" );
     }
+	 	 
+	 #elif defined( portUSE_LGT_TIMER3 )
+	 	 
+    ISR(TIMER3_vect, ISR_NAKED) __attribute__ ((hot, flatten));
+/*  ISR(portSCHEDULER_ISR, ISR_NAKED ISR_NOBLOCK) __attribute__ ((hot, flatten));
+ */
+    ISR(TIMER3_vect)
+    {
+        if (TIFR3 & (1 << OCF3A)) {
+            TIFR3 = 1 << OCF3A;
+            /* on OCR3A match */
+            vPortYieldFromTick();
+            __asm__ __volatile__ ( "reti" );
+        }
+    }
+	  
+	 #else
+         #warning "The user is responsible to provide the corrcet statements for the ISR"
+	 #endif 
+	 
 #else
 
     /*
@@ -764,6 +844,9 @@ extern void prvSetupTimerInterrupt( void );
      *
      * use ISR_NOBLOCK where there is an important timer running, that should preempt the scheduler.
      */
+	 
+	 #if defined( portUSE_WDTO )
+	 
     ISR(portSCHEDULER_ISR) __attribute__ ((hot, flatten));
 /*  ISR(portSCHEDULER_ISR, ISR_NOBLOCK) __attribute__ ((hot, flatten));
  */
@@ -771,4 +854,23 @@ extern void prvSetupTimerInterrupt( void );
     {
         xTaskIncrementTick();
     }
+	 
+	 #elif defined( portUSE_LGT_TIMER3 )
+	 
+    ISR(TIMER3_vect) __attribute__ ((hot, flatten));
+/*  ISR(portSCHEDULER_ISR, ISR_NOBLOCK) __attribute__ ((hot, flatten));
+ */
+    ISR(TIMER3_vect)
+	 {
+        if (TIFR3 & (1 << OCF3A)) {
+            TIFR3 = 1 << OCF3A;
+            /* on OCR3A match */
+            xTaskIncrementTick();
+        }
+	 }
+	 
+    #else
+        #warning "The user is responsible to provide the corrcet statements for the ISR"
+    #endif
+	 
 #endif


### PR DESCRIPTION
Library version with support for MCU LGT8F328 using Timer 3 for tick generation.

In the FreeRTOSVariant.h file, you need to uncomment the line containing "#define portUSE_LGT_TIMER3" (_line 58_) to generate the code for the above MCU.

Guglielmo

P.S.: the "doc" folder also included a file named "tick_sources_lgt_timer3.cpp" (_written following the example of tick_sources_timer0.cpp_), but I don't know how to use it.