### PR TITLE
Remove a slow parameter validation block

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -502,11 +502,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
 
         traceENTER_xQueueGenericCreate( uxQueueLength, uxItemSize, ucQueueType );
 
-        if( ( uxQueueLength > ( UBaseType_t ) 0 ) &&
-            /* Check for multiplication overflow. */
-            ( ( SIZE_MAX / uxQueueLength ) >= uxItemSize ) &&
-            /* Check for addition overflow. */
-            ( ( UBaseType_t ) ( SIZE_MAX - sizeof( Queue_t ) ) >= ( uxQueueLength * uxItemSize ) ) )
+        if( ( uxQueueLength > ( UBaseType_t ) 0 ) )
         {
             /* Allocate enough space to hold the maximum number of items that
              * can be in the queue at any time.  It is valid for uxItemSize to be


### PR DESCRIPTION
This is alternative solution to feilipu/Arduino_FreeRTOS_Library#136

The validation block which contained a division operation is removed. In case of invalid parameters, the allocation properly fails at line 515 and the failure is detected on the next line:
```cplusplus
            pxNewQueue = ( Queue_t * ) pvPortMalloc( sizeof( Queue_t ) + xQueueSizeInBytes );

            if( pxNewQueue != NULL )
            {
                ...
            }
            else
            {
                traceQUEUE_CREATE_FAILED( ucQueueType );
                mtCOVERAGE_TEST_MARKER();
            }
```